### PR TITLE
bam records comperator fixed to satisfy the strick weak orderings, th…

### DIFF
--- a/src/gencore.h
+++ b/src/gencore.h
@@ -32,8 +32,8 @@ struct bamComp{
             else if(b2->core.tid == b1->core.tid && b2->core.pos == b1->core.pos && b2->core.mtid == b1->core.mtid && b2->core.mpos == b1->core.mpos) {
                 if(b2->core.isize > b1->core.isize)
                     return true;
-                else
-                    return (long)b2->data > (long)b1->data;
+                else if(b2->core.isize == b1->core.isize && (long)b2->data > (long)b1->data) return true;
+                else return false;
             } else
                 return false;
         } else {         // b1 is unmapped


### PR DESCRIPTION
as one rule of the Stricklands weak ordering: 

For all x, y in S, if x < y then it is not the case that y < x

however, in the original implementation, in the following case, this condition will not be satisfied and lead to core dump.

b2->core.tid == b1->core.tid && b2->core.pos == b1->core.pos && b2->core.mtid == b1->core.mtid && b2->core.mpos == b1->core.mpos && b2->core.isize > b1->core.isize && (long)b2->data < (long)b1->data

then bamComp(b1, b2) is true, bamComp(b2, b1) is true, as the b->data is a pointer generated in runtime, you can not guarantee b2->data > b1->data is always true or vise versa

my fixed up modification solve this issue and make sure if b1 > b2 then, b2 < b1, always 